### PR TITLE
Texte für Peacekeeping Seite

### DIFF
--- a/source/javascripts/personal.coffee
+++ b/source/javascripts/personal.coffee
@@ -1,6 +1,6 @@
 class PeacekeepingPersonal extends @D3Linechart
   constructor: (@rawData, @options = {}) ->
-    @options = _.defaults(@options, { width: 800, height: 300, margin: {top: 40, right: 30, bottom: 150, left: 80}, ticks: { y: 7, x: 8 } })
+    @options = _.defaults(@options, { width: 800, height: 300, margin: {top: 40, right: 30, bottom: 50, left: 80}, ticks: { y: 7, x: 8 } })
 
   lineClassForElement:  (d) ->
     d[0].Country.toLowerCase()

--- a/source/partials/_peacekeeping_nav.html.haml
+++ b/source/partials/_peacekeeping_nav.html.haml
@@ -1,0 +1,16 @@
+---
+---
+.navbar
+  %ul.nav
+    - index_active = ''
+    - personal_active = ''
+    - if current_page.data.nav == 'index'
+      - index_active = 'active'
+    - if current_page.data.nav == 'personal'
+      - personal_active = 'active'
+    %li(class= index_active)
+      = link_to "/sicherheit/peacekeeping/index.html" do
+        %h4 Finanzbeiträge UN Peacekeeping
+    %li(class= personal_active)
+      = link_to "/sicherheit/peacekeeping/personal.html" do
+        %h4 Personal für UN Peacekeeping in US$

--- a/source/partials/_peacekeeping_nav.html.haml
+++ b/source/partials/_peacekeeping_nav.html.haml
@@ -10,7 +10,7 @@
       - personal_active = 'active'
     %li(class= index_active)
       = link_to "/sicherheit/peacekeeping/index.html" do
-        %h4 Finanzbeiträge UN Peacekeeping
+        %h4 Finanzbeiträge für UN Peacebuilding
     %li(class= personal_active)
       = link_to "/sicherheit/peacekeeping/personal.html" do
-        %h4 Personal für UN Peacekeeping in US$
+        %h4 Gesamtbeiträge für UN Peacebuilding

--- a/source/sicherheit/peacekeeping/index.html.haml
+++ b/source/sicherheit/peacekeeping/index.html.haml
@@ -1,16 +1,10 @@
 ---
 title: Entwicklungsbarometer - Peacekeeping
+nav: index
 ---
 #sicherheit.indikator.sub-indikator
   = link_to "/sicherheit/index.html" do
     %h1.sicherheit Sicherheit
   #peacekeeping
-    .navbar
-      %ul.nav
-        %li.active
-          = link_to "/sicherheit/peacekeeping/index.html" do
-            %h4 Finanzbeiträge UN Peacekeeping
-        %li
-          = link_to "/sicherheit/peacekeeping/personal.html" do
-            %h4 Personal für UN Peacekeeping in US$
+    = partial "partials/peacekeeping_nav"
     .contributions

--- a/source/sicherheit/peacekeeping/index.html.haml
+++ b/source/sicherheit/peacekeeping/index.html.haml
@@ -8,3 +8,7 @@ nav: index
   #peacekeeping
     = partial "partials/peacekeeping_nav"
     .contributions
+    %h2 Finanzbeiträge für UN Peacebuilding
+    .explanation
+      %p Dieser Indikator ist vom CDI übernommen und misst den geschätzten finanziellen Aufwand eines OECD Landes für die Entsendung von Personal in UN Peacebuilding Einsätzen. Vor dem Hintergrund der deutschen Geschichte wird die Beteiligung deutscher Soldaten an militärischen Einsätzen im Ausland kontrovers diskutiert. Es verwundert daher nicht, dass andere OECD Länder im Vergleich zu Deutschland mehr Personal für UN Peacebuilding bereitstellen.
+      %p Datenbeschreibung: Die Daten beruhen auf den vom United Nationas Department for Peacekeeping Operations (UNDPKO) bereitgestellten Zahlen zu Personalbereitstellung für UN Peacekeeping Einsätzen. Die geschätzten Kosten bestehen aus den direkten Kosten pro Person pro Monat und indirekten Kosten. Die direkten Kosten werden vom Center for Global Development auf 9000 US $ pro bereitgestellten Blauhelmsoldaten geschätzt. Die indirekten Kosten beziehen sich auf den Aufwand Soldaten auszubilden und ein stehendes Heer für eventuelle Einsätze bereitzustellen. Die indirekten Kosten werden anhand der maximalen Anzahl von Blauhelmen berechnet die seit 1993 für einen UN Peacekeeping Einsatz bereitgestellt wurden. Personalbereitstellung in der Vergangenheit wird im Vergleich zu aktuelleren UN Peacekeeping Einsätzen abgewertet.

--- a/source/sicherheit/peacekeeping/index.html.haml
+++ b/source/sicherheit/peacekeeping/index.html.haml
@@ -8,9 +8,9 @@ title: Entwicklungsbarometer - Peacekeeping
     .navbar
       %ul.nav
         %li.active
-          = link_to "/sicherheit/peacekeeping/" do
+          = link_to "/sicherheit/peacekeeping/index.html" do
             %h4 Finanzbeiträge UN Peacekeeping
         %li
-          = link_to "/sicherheit/peacekeeping/personal/" do
+          = link_to "/sicherheit/peacekeeping/personal.html" do
             %h4 Personal für UN Peacekeeping in US$
     .contributions

--- a/source/sicherheit/peacekeeping/personal.html.haml
+++ b/source/sicherheit/peacekeeping/personal.html.haml
@@ -1,16 +1,10 @@
 ---
 title: Entwicklungsbarometer - Peacekeeping Personal
+nav: personal
 ---
 #sicherheit.indikator.sub-indikator
   = link_to "/sicherheit/index.html" do
     %h1.sicherheit Sicherheit
   #peacekeeping
-    .navbar
-      %ul.nav
-        %li
-          = link_to "/sicherheit/peacekeeping/index.html" do
-            %h4 Finanzbeiträge UN Peacekeeping
-        %li.active
-          = link_to "/sicherheit/peacekeeping/personal.html" do
-            %h4 Personal für UN Peacekeeping in US$
+    = partial "partials/peacekeeping_nav"
     #personal

--- a/source/sicherheit/peacekeeping/personal.html.haml
+++ b/source/sicherheit/peacekeeping/personal.html.haml
@@ -8,9 +8,9 @@ title: Entwicklungsbarometer - Peacekeeping Personal
     .navbar
       %ul.nav
         %li
-          = link_to "/sicherheit/peacekeeping/" do
+          = link_to "/sicherheit/peacekeeping/index.html" do
             %h4 Finanzbeiträge UN Peacekeeping
         %li.active
-          = link_to "/sicherheit/peacekeeping/personal/" do
+          = link_to "/sicherheit/peacekeeping/personal.html" do
             %h4 Personal für UN Peacekeeping in US$
     #personal

--- a/source/sicherheit/peacekeeping/personal.html.haml
+++ b/source/sicherheit/peacekeeping/personal.html.haml
@@ -8,3 +8,7 @@ nav: personal
   #peacekeeping
     = partial "partials/peacekeeping_nav"
     #personal
+    %h2 Gesamtbeiträge für UN Peacebuilding
+    .explanation
+      %p Dieser Indikator ist vom CDI übernommen und misst den geschätzten finanziellen Aufwand eines OECD Landes für die Entsendung von Personal in UN Peacebuilding Einsätzen. Vor dem Hintergrund der deutschen Geschichte wird die Beteiligung deutscher Soldaten an militärischen Einsätzen im Ausland kontrovers diskutiert. Es verwundert daher nicht, dass andere OECD Länder im Vergleich zu Deutschland mehr Personal für UN Peacebuilding bereitstellen.
+      %p Datenbeschreibung: Die Daten beruhen auf den vom United Nationas Department for Peacekeeping Operations (UNDPKO) bereitgestellten Zahlen zu Personalbereitstellung für UN Peacekeeping Einsätzen. Die geschätzten Kosten bestehen aus den direkten Kosten pro Person pro Monat und indirekten Kosten. Die direkten Kosten werden vom Center for Global Development auf 9000 US $ pro bereitgestellten Blauhelmsoldaten geschätzt. Die indirekten Kosten beziehen sich auf den Aufwand Soldaten auszubilden und ein stehendes Heer für eventuelle Einsätze bereitzustellen. Die indirekten Kosten werden anhand der maximalen Anzahl von Blauhelmen berechnet die seit 1993 für einen UN Peacekeeping Einsatz bereitgestellt wurden. Personalbereitstellung in der Vergangenheit wird im Vergleich zu aktuelleren UN Peacekeeping Einsätzen abgewertet.


### PR DESCRIPTION
## Beschreibung

Texte für Peacekeeping und Subnavigation ausgelagert
## Dazugehöriges Issue
#73
## Änderungen
### Hinzugefügt

Texte für Peacekeeping
Frontmatter für Subnavigation
### Geändert

Subnavigation in der 3. Ebene in Partial ausgelagert.
### Entfernt

Navigation aus den Peacekeeping Seiten der 3. Ebene entfernt und partial benutzt
