### PR TITLE
Change headline in export subindicator

### DIFF
--- a/source/sicherheit/ruestung/freedom-index.html.haml
+++ b/source/sicherheit/ruestung/freedom-index.html.haml
@@ -9,7 +9,7 @@ title: Entwicklungsbarometer - Freedom Index
       %ul.nav
         %li
           = link_to "/sicherheit/ruestung/index.html" do
-            %h4 Schädliche Waffenexporte
+            %h4 Kritische Waffenexporte
         %li
           %h4 Deutsche Waffenexporte im Detail
         %li

--- a/source/sicherheit/ruestung/index.html.haml
+++ b/source/sicherheit/ruestung/index.html.haml
@@ -9,7 +9,7 @@ title: Entwicklungsbarometer - Rüstung
       %ul.nav
         %li.active
           = link_to "/sicherheit/ruestung/index.html" do
-            %h4 Schädliche Waffenexporte
+            %h4 Kritische Waffenexporte
         %li
           %h4 Deutsche Waffenexporte im Detail
         %li
@@ -18,7 +18,7 @@ title: Entwicklungsbarometer - Rüstung
           = link_to "/sicherheit/ruestung/freedom-index.html" do
             %h4 Anteil kritische Waffenexporte am GDP
   .exports-percent-gdp.barchart
-  %h2 Schädliche Waffenexporte
+  %h2 Kritische Waffenexporte
   .explanation
     %p Frieden und Sicherheit sind wesentliche Voraussetzung für Entwicklung. Bewaffnete Konflikte zerstören weltweit die Lebensgrundlagen von Menschen. Die Produktion von Waren und Dienstleistungen bricht ein, die Gesundheitsversorgung und das Bildungsystem brechen zusammen und Menschen verlassen ihre Heimat und suchen in Flüchtlingslagern und im Ausland Schutz. Die negativen Folgen von Krieg und bewaffneten Konflikten auf Entwicklung und Armutsbekämpfung sind zahlreich. Die meisten Entwicklungsländer produzieren ihre Waffen nicht selber, sondern erhalten Waffenlieferungen von Industrieländern. Vor allem wenn Entwicklungsländer nicht demokratisch regiert werden, besteht ein hohes Risiko, dass Waffenlieferung bewaffnete Konflikte und Krieg fördern. Waffenexporte in nicht-demokratische Staaten sind daher grundsätzlich kritisch zu betrachten.
   .explanation


### PR DESCRIPTION
Überschrift geändert im Exportbereich des Sicherheitsindkators von "Schädlichen Waffenexporten" zu "Kritische Waffenexporte"
